### PR TITLE
Refactoring of Icon handling. Closes #13

### DIFF
--- a/OpenHere/OpenHere.psd1
+++ b/OpenHere/OpenHere.psd1
@@ -114,6 +114,7 @@
 v3.0.0: (2020-04-07)
 - Support for PowerShell Core 7 RTM x64 (or any x64 major version)
 - Support for WSL/Bash
+- Shell shortcut icons can be derived from shells' EXE binaries.
 
 v2.0.5: (2020-03-01)
 - Manifest description update.

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ Windows Terminal doesn't responds to RunAs request from the context menu. This p
 Yes, see the section [Planned features.](https://github.com/KUTlime/PowerShell-Open-Here-Module#Planned-features)
 
 ### Can I customize the shortcut icon?
-Yes, override the `Icon.ico` file in `%LOCALAPPDATA%\OpenHere\[ShellType]` and you are good to go.
+By default, OpenHere module uses its own icons in shell context menus. If the `-UseExeIcon` switch is used when shortcut is created, the default icons are **not** generated. These default icons are written in `%LOCALAPPDATA%\OpenHere\[ShellType]`. Every shell has its own `Icon.ico` file in the corresponding subfolder. You can customize icons by overriding these `Icon.ico` files.
 
 ### Can I override the names?
 Yes, just run `Set-OpenHereShortcut` with a new configuration.


### PR DESCRIPTION
Shells' EXE binary icons can be now used as shell shortcut icons instead the default set provided by module. This closes #13 